### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The publicly available search directory can be found [here](https://www.orgbook.
 
 ### What does the OrgBook API offer?
 
-The OrgBook API exposes a number of RESTful endpoints that make it simple to integrate publicly available verifiable data about registered organizations into your application. Some of the features that are available through the API include, but are not limited to:
+The OrgBook API exposes a number of RESTful endpoints that make it simple to integrate publicly available, verifiable data about registered organizations into your applications. Some of the features that are available through the API include, but are not limited to:
 
 - Autocomplete-enabled organization name search
 - Organization data retrieval, in the form of verifiable credentials (including registration number, business number, entity type, entity status, etc.)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Various developer tools and documentation for using the OrgBook API as part of t
     - [What is OrgBook](#what-is-orgbook)
     - [What does the OrgBook API Offer?](#what-does-the-orgbook-api-offer)
 - [Getting Started](#getting-started)
-    - [Open API Specification](#open-api-specification)
     - [Documentation](#documentation)
+    - [Open API Specification](#open-api-specification)
     - [Demo](#demo)
 - [Contributing](#contributing)
 - [License](#license)
@@ -20,34 +20,33 @@ Various developer tools and documentation for using the OrgBook API as part of t
 
 OrgBook has been developed by the Government of British Columbia as a searchable public directory of open verifiable data about organizations legally registered in the province. Orgbook is leveraging novel blockchain-based technology, powered by the web, to help move BC into a digital economy.
 
-The publicly available search directory can be found [here](https://www.orgbook.gov.bc.ca/en/home), however an API has also been made available to allow developers to integrate verifiable organization data search into their own applications. This repository serves as the central source of information and tools for the OrgBook API.
+The publicly available search directory can be found [here](https://www.orgbook.gov.bc.ca/en/home), however an API has also been made available to allow developers to integrate various OrgBook features into their own applications. This repository serves as the central source of information and tools for the API.
 
 ### What does the OrgBook API offer?
 
-The OrgBook API offers a number of features that make it simple to integrate a fully featured verifiable organization data search into applications. Some of these features include, but are not limited to:
+The OrgBook API exposes a number of RESTful endpoints that make it simple to integrate publicly available verifiable data about registered organizations into your application. Some of the features that are available through the API include, but are not limited to:
 
-- Autocomplete name search
-- Basic organization search
-- Faceted organization search
-- Organization credential verification
+- Autocomplete-enabled organization name search
+- Organization data retrieval, in the form of verifiable credentials (including registration number, business number, entity type, entity status, etc.)
 - Credential issuer search
-- Credential type search
+- Credential type search,
+- Credential verification
 
 ## Getting started
 
 A number of resources have been set up in this repository as a guide to using the OrgBook API.
 
-### Open API specification
-
-As a first step, you may wish to check out the [Open API specification](https://orgbook.gov.bc.ca/api/v3/) of the OrgBook API. The production API is currently in its third version (v3) and you are encouraged to use the most up-to-date production version in your applications to avoid any issues with backward compatibility. The Open API specification is a good way to catalogue the various endpoints available and to get a preliminary understanding of API requests and responses.
-
 ### Documentation
 
-This will likely be your main go-to guide. Please see the [documentation](./docs/README.md) for a comprehensive overview of the OrgBook API along with examples and implementation instructions for the most common scenarios.
+If you are just starting out, this should be your main go-to guide. Please see the [documentation](./docs/README.md) for a comprehensive overview of the OrgBook API along with examples and implementation instructions for the most common application use cases.
+
+### Open API specification
+
+You may wish to check out the [Open API specification](https://orgbook.gov.bc.ca/api/v3/) if you are interested in a deeper look into a catalogue of all the endpoints available. You are encouraged to use the most up-to-date production version (v3) of the API in your applications to avoid any issues with backward compatibility.
 
 ### Demo
 
-To see the OrgBook API in action please see a [demo](./demo/README.md) that has been developed featuring the use of various endpoints to create a full-featured verifiable organization data search tool.
+To see the OrgBook API in action, please see a [demo](./demo/README.md) that has been developed featuring the use of various endpoints to create a full-featured verifiable organization data search tool.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The OrgBook API exposes a number of RESTful endpoints that make it simple to int
 - Autocomplete-enabled organization name search
 - Organization data retrieval, in the form of verifiable credentials (including registration number, business number, entity type, entity status, etc.)
 - Credential issuer search
-- Credential type search,
+- Credential type search
 - Credential verification
 
 ## Getting started

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,19 @@
 # OrgBook API (v3) Documentation
 
-Documentation for OrgBook API usage.
+This document has been created as a first reference for the OrgBook API. When you become more familiar with the basic concepts, you may want to go on to explore the [OpenAPI Specification](https://orgbook.gov.bc.ca/api/v3/) and all of the endpoints available.
+
+## Introduction
+
+### What is OrgBook?
+OrgBook is a type of [Hyperledger Aries](https://github.com/hyperledger/aries) Verifiable Credential Registry ([Aries VCR](https://github.com/bcgov/aries-vcr)). Aries VCR is simply a set of software tools that make it easy to host and issue [verifiable credentials](https://en.wikipedia.org/wiki/Verifiable_credentials) of any type. OrgBook is a specific implementation of an Aries VCR built by the Government of British Columbia, that hosts verifiable credentials about organizations registered in the province. ___The key point to remember is that (almost) everything is a credential in OrgBook.___ Everything from an organization's registration information, to its business number and its relations to other organizations within the province, is stored as a verifiable credential in OrgBook. Credentials are issued to OrgBook via a credential issuer. OrgBook can store credentials from one or more issuers.
+
+The OrgBook API is a RESTful interface to OrgBook, that has been purposefully built for developers to access and integrate the verifiable credentials (i.e. data about registered organizations) from OrgBook as part of their own applications. The following documentation outlines the most common scenarios developers are likely to use the OrgBook API for.
 
 ## Table of contents
+- [Introduction](#introduction)
 - [Common scenarios](#common-scenarios)
+  - [I want to get a list of credential issuers registered in OrgBook](#i-want-to-get-a-list-of-credential-issuers-registered-in-orgbook)
+  - [I want to get a list of available credential types in OrgBook](#i-want-to-get-a-list-of-available-credential-types-in-orgBook)
   - [Name search with autocomplete](#name-search-with-autocomplete)
   - [Basic organization search](#basic-organization-search)
   - [Faceted organization search](#faceted-organization-search)
@@ -13,9 +23,75 @@ Documentation for OrgBook API usage.
 
 ## Common scenarios
 
-This section goes through some of the most common use cases for the OrgBook API and offers some implementation guides for each of the scenarios.
+### I want to get a list of credential issuers registered in OrgBook
 
-_If you would like to see how some of these features are implemented in a real application, feel free to check out the [demo](/demo/README.md)._
+To do this, make a request to the `/issuer` endpoint. The response will look something like:
+
+```json
+{
+  "total": 2,
+  "page_size": 10,
+  "page": 1,
+  "first_index": 1,
+  "last_index": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "has_logo": true,
+      "create_timestamp": "2020-02-14T14:27:35.624957-08:00",
+      "update_timestamp": "2020-09-18T13:55:52.670973-07:00",
+      "did": "HR6vs6GEZ8rHaVgjg2WodM",
+      "name": "BC Corporate Registry",
+      "abbreviation": "BCReg",
+      "email": "bcregistries@gov.bc.ca",
+      "url": "https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services",
+      "endpoint": ""
+    },
+    ...
+  ]
+}
+```
+
+The `results` field is a list of issuers that have registered with OrgBook. They may or may not have issued any credentials yet, however developers can find out what type of credentials are issued by a specific issuer by querying the `issuer/{id}/credentialtype` endpoint. In the above example, the issuer with an `id` of `1` is the BC Corporate Registry which issues credentials to OrgBook corresponding to an organization's registration in the province, among others.
+
+### I want to get a list of available credential types in OrgBook
+
+To do this, make a request to the `/credentialtype` endpoint. The response will look something like:
+
+```json
+{
+  "total": 6,
+  "page_size": 10,
+  "page": 1,
+  "first_index": 1,
+  "last_index": 6,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "issuer": { ... },
+      "has_logo": true,
+      "create_timestamp": "2020-02-14T14:27:35.689210-08:00",
+      "update_timestamp": "2020-10-06T20:00:35.714822-07:00",
+      "description": "registration.registries.ca",
+      "credential_def_id": "HR6vs6GEZ8rHaVgjg2WodM:3:CL:41051:tag",
+      "last_issue_date": "2020-10-06T20:00:35.714729-07:00",
+      "url": "/bcreg/incorporation",
+      "schema": { ... }
+    },
+    ...
+  ]
+}
+```
+
+The `results` field is a list of credential types that issuers have indicated they will be issuing when they register with OrgBook. This doesn't necessarily mean there are any credentials of the indicated types in OrgBook, but simply that they may be issued at some point or another. For example, organization addresses are issued as a credential, however BC Registries has not currently made credentials of that type available in OrgBook.
+
+_Note: If you are interested in understanding the structure of address credentials, the OrgBook development team has a [non-production deployment](https://dev.orgbook.gov.bc.ca) of OrgBook with [hypothetical organizations](https://dev.orgbook.gov.bc.ca/en/organization/registration.registries.ca/BC0356343/cred/6741681) that have address credentials._
+
+OrgBook allows one to search organizations that have been issued a specific type of credential, and a good example of this can be seen in the [Advanced Search](https://orgbook.gov.bc.ca/en/advanced-search). The list of credential types is used to populate a select input, which narrows the search down to only those organizations that have been issued a credential of the selected type. For example, one might be interested in searching for organizations that have been issued a Cannabis Retail Store License.
 
 ### Name search with autocomplete
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,27 +5,27 @@ This document has been created as a first reference for the OrgBook API. When yo
 ## Introduction
 
 ### What is OrgBook?
-OrgBook is a type of [Hyperledger Aries](https://github.com/hyperledger/aries) Verifiable Credential Registry ([Aries VCR](https://github.com/bcgov/aries-vcr)). Aries VCR is simply a set of software tools that make it easy to host and issue [verifiable credentials](https://en.wikipedia.org/wiki/Verifiable_credentials) of any type. OrgBook is a specific implementation of an Aries VCR built by the Government of British Columbia, that hosts verifiable credentials about organizations registered in the province. ___The key point to remember is that (almost) everything is a credential in OrgBook.___ Everything from an organization's registration information, to its business number and its relations to other organizations within the province, is stored as a verifiable credential in OrgBook. Credentials are issued to OrgBook via a credential issuer. OrgBook can store credentials from one or more issuers.
+OrgBook is a type of [Hyperledger Aries](https://github.com/hyperledger/aries) Verifiable Credential Registry ([Aries VCR](https://github.com/bcgov/aries-vcr)). Aries VCR is simply a set of software tools that make it easy to host and issue [verifiable credentials](https://en.wikipedia.org/wiki/Verifiable_credentials) of any type. OrgBook is a specific implementation of an Aries VCR built by the Government of British Columbia, that hosts verifiable credentials about organizations registered in the province. ___The key point to remember is that (almost) everything is a credential in OrgBook.___ Everything from an organization's registration information, to its business number and its relations to other organizations within the province, is stored as a verifiable credential in OrgBook. Credentials are issued to OrgBook from a credential issuer. OrgBook can store credentials from one or more issuers.
 
-The OrgBook API is a RESTful interface to OrgBook, that has been purposefully built for developers to access and integrate the verifiable credentials (i.e. data about registered organizations) from OrgBook as part of their own applications. The following documentation outlines the most common scenarios developers are likely to use the OrgBook API for.
+The OrgBook API is a RESTful interface to OrgBook. It has been purposefully built for developers to access and integrate verifiable credentials (i.e. data about registered organizations) from OrgBook into their own applications. The following documentation outlines the most common scenarios that developers are likely to use the OrgBook API for, including use cases for specific features that most will be looking to build into their applications.
 
 ## Table of contents
 - [Introduction](#introduction)
 - [Common scenarios](#common-scenarios)
   - [I want to get a list of credential issuers registered in OrgBook](#i-want-to-get-a-list-of-credential-issuers-registered-in-orgbook)
   - [I want to get a list of available credential types in OrgBook](#i-want-to-get-a-list-of-available-credential-types-in-orgBook)
-  - [Name search with autocomplete](#name-search-with-autocomplete)
-  - [Basic organization search](#basic-organization-search)
-  - [Faceted organization search](#faceted-organization-search)
-  <!-- - [Organization credential verification](#organization-credential-verification) -->
-  <!-- - [Credential issuer search](#credential-issuer-search) -->
-  <!-- - [Credential type search](#credential-type-search) -->
+  - [I want to build a legal name search component in my application](#i-want-to-build-a-legal-name-search-component-in-my-application)
+    - [Implementation Example 1](#implementation-example-1)
+  - [I want to auto-populate form fields with organization info](#i-want-to-auto-populate-form-fields-with-organization-info)
+    - [Step 1. Query for a topic](#step-1-query-for-a-topic)
+    - [Step 2. Query for credentials](#step-2-query-for-credentials)
+    - [Implementation Example 2](#implementation-example-2)
 
 ## Common scenarios
 
 ### I want to get a list of credential issuers registered in OrgBook
 
-To do this, make a request to the `/issuer` endpoint. The response will look something like:
+To do this, make a `GET` request to the `/issuer` endpoint. The response will look something like:
 
 ```json
 {
@@ -54,11 +54,11 @@ To do this, make a request to the `/issuer` endpoint. The response will look som
 }
 ```
 
-The `results` field is a list of issuers that have registered with OrgBook. They may or may not have issued any credentials yet, however developers can find out what type of credentials are issued by a specific issuer by querying the `issuer/{id}/credentialtype` endpoint. In the above example, the issuer with an `id` of `1` is the BC Corporate Registry which issues credentials to OrgBook corresponding to an organization's registration in the province, among others.
+The results are a list of issuers that have registered with OrgBook. They may or may not have issued any credentials yet, however developers can find out what type of credentials are issued by a specific issuer, by making a `GET` request to the `issuer/{id}/credentialtype` endpoint. In the above example, the issuer with an `id` of `1` is the BC Corporate Registry which issues credentials to OrgBook corresponding to an organization's registration in the province, among others.
 
 ### I want to get a list of available credential types in OrgBook
 
-To do this, make a request to the `/credentialtype` endpoint. The response will look something like:
+To do this, make a `GET` request to the `/credentialtype` endpoint. The response will look something like:
 
 ```json
 {
@@ -87,176 +87,258 @@ To do this, make a request to the `/credentialtype` endpoint. The response will 
 }
 ```
 
-The `results` field is a list of credential types that issuers have indicated they will be issuing when they register with OrgBook. This doesn't necessarily mean there are any credentials of the indicated types in OrgBook, but simply that they may be issued at some point or another. For example, organization addresses are issued as a credential, however BC Registries has not currently made credentials of that type available in OrgBook.
+The results are a list of credential types that issuers have indicated they will be issuing when they register with OrgBook. This doesn't necessarily mean there are any credentials of the indicated types in OrgBook, but simply that they may be issued at some point or another. For example, organization addresses are issued as a credential, however BC Registries has not currently made credentials of that type available in OrgBook.
 
-_Note: If you are interested in understanding the structure of address credentials, the OrgBook development team has a [non-production deployment](https://dev.orgbook.gov.bc.ca) of OrgBook with [hypothetical organizations](https://dev.orgbook.gov.bc.ca/en/organization/registration.registries.ca/BC0356343/cred/6741681) that have address credentials._
+_Note: If you are interested in seeing the structure of address credentials, the OrgBook developer team has a [non-production deployment](https://dev.orgbook.gov.bc.ca) of OrgBook with [hypothetical organizations](https://dev.orgbook.gov.bc.ca/en/organization/registration.registries.ca/BC0356343/cred/6741681) that have address credentials._
 
 OrgBook allows one to search organizations that have been issued a specific type of credential, and a good example of this can be seen in the [Advanced Search](https://orgbook.gov.bc.ca/en/advanced-search). The list of credential types is used to populate a select input, which narrows the search down to only those organizations that have been issued a credential of the selected type. For example, one might be interested in searching for organizations that have been issued a Cannabis Retail Store License.
 
-### Name search with autocomplete
+### I want to build a legal name search component in my application
 
-This is likely to be the most popular use case of the OrgBook API, giving you the ability to create a name lookup feature in your application for legally registered organizations, with autocomplete functionality.
+Developers often want to include a search feature for legal names of registered BC organizations in their applications (usually to [auto-populate form inputs](#i-want-to-auto-populate-form-fields-with-organization-info)). It is so commonplace, that the OrgBook developer team created the `/search/autocomplete` endpoint.
 
-The `/search/autocomplete` path has been created specifically for this.
+Make a `GET` request to the `/search/autocomplete` endpoint, passing a string of characters to the `q` query parameter in the request URL. OrgBook will try to match the string of characters to names of registered organizations. For example, if you wanted to query for the name `'Power Corp'` you would format the request like: `/search/autocomplete?q=Power%20Corp`. The response will look something like:
 
-`/search/autocomplete` takes a query parameter, `q`: a query string that will match the most closely related organization names in OrgBook. There are optional query parameters (described below) that can be provided, however default values are used when these query parameters are not included.
-
-Example (using `'abc'` as the query string):
-
-#### Request
-
-```
-/search/autocomplete?q=abc&inactive=false&revoked=false
-```
-
-The `inactive` query parameter denotes whether names of discontinued entities should be returned in the results. The `revoked` query parameter denotes whether entities with invalid credentials should be returned in the results. By default, only currently operating organizations with valid credentials are queried for.
-
-#### Response
-
-The API response will look something like this type definition:
-
-_**Note:** the type names are arbitrary, the type definition is more important here._
-
-```
-interface AggregateAutocompleteResponse {
-  total: number;
-  first_index: number;
-  last_index: number;
-  results: AggregateAutocomplete[];
-}
-```
-What you will be most interested in is the `results` field which is a list of closely matching entity names in OrgBook BC, and has the following type definition:
-
-```
-interface AggregateAutocomplete {
-  type: string;
-  value: string;
-  score: number;
-  topic_source_id: string;
-  topic_type: string;
-  credential_id: string;
-}
-```
-
-Results are mostly returned in batches of up to 10 in descending search `score` order. More specific query strings will result in fewer results returned with higher search scores. Non-matching query strings will return empty results.
-The main fields you will be interested are:
-* `type`: The data field that autocomplete search is based on (example: `'name'`).
-* `value`: The value of the data field that autocomplete search is based on (example: `'ABC LTD.'`).
-
-#### Example
-
-> Checkout this [example](https://stackblitz.com/edit/js-uum64f?file=index.js) on Stackblitz for a simple implementation using jQuery and plain HTML.
-
-### Basic organization search
-
-You will likely want more comprehensive information about an organization such as the type of organization, its business number, when it was registered, whether the organization is still active, even information about related organizations.
-
-The `/search/topic` path is available for basic organization searches and returns data in the form of one or more verifiable credentials about the ___topic___ of interest.
-
-`/search/topic` takes a query parameter, `name`: a query string that will match the most closely related organization names in OrgBook. There are also optional query parameters (described below) that can be passed, and default values will be used when these query parameters are not included.
-
-#### Request
-
-Example (using `'abc'` as the query string):
-
-```
-/search/topic?name=abc&inactive=false&latest=true&revoked=false
-```
-
-The `inactive` query parameter denotes whether names of discontinued entities should be returned in the results. The `revoked` query parameter denotes whether entities with invalid credentials should be returned in the results. Since this path returns verifiable credentials, the `latest` query parameter denotes whether only the most recent credential(s) should be returned. By default, only currently operating organizations with the latest valid credentials are queried for.
-
-#### Response
-
-The API response will have the following type definition:
-
-```
-interface TopicResponse {
-  total: number;
-  page_size: number;
-  page: number;
-  first_index: number;
-  last_index: number;
-  next: string;
-  previous: string;
-  results: CredentialTopicSearch[];
+```json
+  "total": 10,
+  "first_index": 1,
+  "last_index": 10,
+  "results": [
+    {
+      "type": "name",
+      "value": "U3 POWER CORP.",
+      "score": 122.19571,
+      "topic_source_id": "BC0772006",
+      "topic_type": "registration.registries.ca",
+      "credential_id": "c0d330b4-bf99-4cf1-9da1-9dd7207bfd88"
+    },
+    {
+      "type": "name",
+      "value": "TRITON POWER CORP.",
+      "score": 121.502174,
+      "topic_source_id": "BC0205366",
+      "topic_type": "registration.registries.ca",
+      "credential_id": "1f77e47d-94f0-4e68-9df2-9796b4d68e1a"
+    },
+    {
+      "type": "name",
+      "value": "STOTHERT POWER CORP.",
+      "score": 121.502174,
+      "topic_source_id": "BC0070832",
+      "topic_type": "registration.registries.ca",
+      "credential_id": "ec70b489-a66b-499a-ba92-d477b1c37138"
+    },
+    {
+      "type": "name",
+      "value": "BOSS POWER CORP.",
+      "score": 121.502174,
+      "topic_source_id": "BC0230487",
+      "topic_type": "registration.registries.ca",
+      "credential_id": "fd6d822a-9ec7-4abb-96e0-c2edaaff2108"
+    },
+    ...
+  ]
 }
 ```
 
-Results are returned in pages of up to 10 similarly matching entities to the name query (the number of results in the current response are indicated in the `page_size` field). The `total` field will indicate whether there are more results available than what's in the current page, and if so, `next` and `previous` URLs will be included in the response for accessing the next or previous pages of results, respectively. More specific query strings will result in fewer results and pages returned. Non-matching query strings will return empty pages.
+Results are returned in batches of up to 10 closely matching organization names, each with a match `score`. The results are sorted from the highest to the lowest score, therefore closer matches will be at the top of the results. OrgBook will return fewer results with higher scores, as you provide more exactly matching query strings. If OrgBook is unable to match a query string to any organization name, it will return empty results.
 
-The `results` field is a list of credentials for closely or exactly matching entities in OrgBook, and has the following type definition:
+There are optional parameters that you can attach to the request:
+* The `inactive` query parameter denotes whether inactive organizations (i.e. those with a status of `'Historical'`) should be included in the results (defaults to `'false'`).
+* The `revoked` query parameter denotes whether organizations with revoked registration credentials should be returned in the results (defaults to `'false'`).
 
-```
-interface CredentialTopicSearch {
-  id: number;
-  create_timestamp: Date;
-  update_timestamp: Date;
-  effective_date: Date;
-  inactive: boolean;
-  latest: boolean;
-  revoked: boolean;
-  revoked_date: Date;
-  credential_id: string;
-  credential_set: CredentialSet;
-  credential_type: CredentialType;
-  attributes: CredentialAttribute[];
-  names: CredentialName[];
-  topic: CredentialTopicExt;
-  related_topics: CredentialNamedTopic[];
+#### Implementation Example 1
+
+> Checkout this [example](https://stackblitz.com/edit/js-uum64f) on StackBlitz for a simple implementation of an autocomplete name search using jQuery UI and plain HTML.
+
+_Another simple approach could be to attach a `'keypress'` event listener to a text input. As a user types, requests are made to `/search/autocomplete` with the value of the input. You may want to employ techniques, like debouncing, to reduce the number of calls to the API server. Better yet, use an existing UI library that provides these features out of the box and simply pass autocomplete results to display._
+
+### I want to auto-populate form fields with organization info
+
+Developers often create applications that require information about registered BC organizations in their applications. For example, you could be building an application that issues a loan or a certificate only to registered BC organizations. You currently have a form with fields for an organization's name, BC Registries number, CRA business number, type, and status that need to be filled in. The OrgBook API enables you to pull this information from OrgBook credentials. You can then programmatically populate the fields in your form using the credential data.
+
+You simply need to call a few endpoints in the OrgBook API in the following order (assuming you have already performed an [autocomplete name search](#i-want-to-build-a-legal-name-search-component-in-my-application) and are using one of the results from that request, or you know the BC Registries number of the organization you require information about):
+
+#### Step 1. Query for a topic
+
+Make a `GET` request to the `/search/topic` endpoint, passing in the BC Registries number (this is the `topic_source_id` field in an autocomplete result) to the `name` query parameter in the request URL.
+
+There are optional parameters that you can attach to the request:
+* The `inactive` query parameter denotes whether inactive organizations (i.e. those with a status of `'Historical'`) should be included in the results (defaults to `'false'`).
+* The `revoked` query parameter denotes whether organizations with revoked registration credentials should be returned in the results (defaults to `'false'`).
+* The `latest` query parameter denotes whether only the most recently issued credential(s) should be returned (defaults to `'true'`).
+
+For example, if you wanted to query for information about `'U3 POWER CORP.'` you would format the request like: `/search/topic?name=BC0772006`. The response will look something like:
+
+```json
+{
+  "total": 1,
+  "page_size": 10,
+  "page": 1,
+  "first_index": 1,
+  "last_index": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1092374,
+      "create_timestamp": "2020-09-17T19:09:38.719347-07:00",
+      "update_timestamp": "2020-09-17T19:09:38.746805-07:00",
+      "effective_date": "2006-10-17T16:58:42-07:00",
+      "inactive": false,
+      "latest": true,
+      "revoked": false,
+      "revoked_date": null,
+      "credential_id": "c0d330b4-bf99-4cf1-9da1-9dd7207bfd88",
+      "credential_set": { ... },
+      "credential_type": { ... },
+      "attributes": [ ... ],
+      "names": [ ... ],
+      "topic": {
+        "id": 787297,
+        "create_timestamp": "2020-09-17T19:09:38.681116-07:00",
+        "update_timestamp": "2020-09-17T19:09:38.681143-07:00",
+        "source_id": "BC0772006",
+        "type": "registration.registries.ca",
+        "names": [ ... ],
+        "local_name": { ... },
+        "remote_name": null,
+        "addresses": [],
+        "attributes": [ ... ]
+      },
+      "related_topics": []
+    },
+    ...
+  ]
 }
 ```
 
-The `inactive`, `latest`, `revoked` and `revoked_date` fields are self explanatory. `effective_date` indicates when the credential was activated.
+Each of the results returned is a foundational credential for the ___topic___ you are searching for. A foundational credential is generated when an organization is first registered in OrgBook. All other credentials for this organization are then linked (related to) this credential. It is possible to receive more than 1 foundational credential back from this query (especially for those belonging to related organizations). Results are returned in pages of up to 10 closely matching entities to the name you provide in the query. Typically you would iterate through the results and find the first credential where the `source_id` under the `topic` field matches the BC Registries number you passed in the name query.
 
-_**Note:** `effective_date` is not the same as incorporation/registration date. It simply denotes the last time a credential was activated for this entity in OrgBook._
+#### Step 2. Query for credentials
 
-Organization data is found in the `topic` field, which has the following type definition:
+Locate the `topic` field from the previous result and, within that, locate the `id` field. The topic id can be used to obtain all OrgBook credentials for an organization of interest.
 
-```
-interface CredentialTopicExt {
-  id: number;
-  create_timestamp: Date;
-  update_timestamp: Date;
-  source_id: string;
-  type: string;
-  names: CredentialName[];
-  local_name: CredentialName;
-  remote_name: CredentialName;
-  addresses: CredentialAddress[];
-  attributes: TopicAttribute[];
+Make a `GET` request to the `/search/credential` endpoint, passing in the topic id from the topic search result to the `topic_id` query parameter in the request URL.
+
+The same optional parameters for the `/search/topic` endpoint can be attached to the request.
+
+For example, if you wanted to query for all of the credentials of `'U3 POWER CORP.'` you would format the request like: `/search/credentials?topic_id=787297`. The response looks almost identical to the topic search, except all credentials are returned for this one organization:
+
+```json
+{
+  "total": 2,
+  "page_size": 10,
+  "page": 1,
+  "first_index": 1,
+  "last_index": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1092374,
+      "create_timestamp": "2020-09-17T19:09:38.719347-07:00",
+      "update_timestamp": "2020-09-17T19:09:38.746805-07:00",
+      "effective_date": "2006-10-17T16:58:42-07:00",
+      "inactive": false,
+      "latest": true,
+      "revoked": false,
+      "revoked_date": null,
+      "credential_id": "c0d330b4-bf99-4cf1-9da1-9dd7207bfd88",
+      "credential_set": { ... },
+      "credential_type": {
+        "id": 1,
+        "issuer": { ... },
+        "has_logo": true,
+        "create_timestamp": "2020-09-16T11:17:48.917070-07:00",
+        "update_timestamp": "2020-09-23T17:33:09.918448-07:00",
+        "description": "registration.registries.ca",
+        "credential_def_id": "9vnQTCy6NQ7mxUVhLtaPZY:3:CL:39771:default",
+        "last_issue_date": "2020-09-23T08:51:02.884222-07:00",
+        "url": "/bcreg/incorporation",
+        "schema": { ... }
+      },
+      "addresses": [],
+      "attributes": [
+        ...
+        {
+          "id": 7464375,
+          "type": "entity_status",
+          "format": "category",
+          "value": "ACT",
+          "credential_id": 1092374
+        },
+        ...
+        {
+          "id": 7464377,
+          "type": "entity_type",
+          "format": "category",
+          "value": "BC",
+          "credential_id": 1092374
+        },
+        ...
+      ],
+      "names": [
+        {
+          "id": 1067982,
+          "text": "U3 POWER CORP.",
+          "language": null,
+          "credential_id": 1092374,
+          "type": "entity_name"
+        }
+      ],
+      "topic": { ... },
+      "related_topics": []
+    },
+    {
+      "id": 2888463,
+      "create_timestamp": "2020-09-23T22:31:49.875342-07:00",
+      "update_timestamp": "2020-09-23T22:31:49.934100-07:00",
+      "effective_date": "2006-10-17T16:58:42-07:00",
+      "inactive": false,
+      "latest": true,
+      "revoked": false,
+      "revoked_date": null,
+      "credential_id": "73ae94b1-3582-41c2-8076-eceabfe20ae8",
+      "credential_set": { ... },
+      "credential_type": {
+        "id": 4,
+        "issuer": { ... },
+        "has_logo": true,
+        "create_timestamp": "2020-09-16T11:17:49.057504-07:00",
+        "update_timestamp": "2020-09-24T10:48:42.356094-07:00",
+        "description": "business_number.registries.ca",
+        "credential_def_id": "9vnQTCy6NQ7mxUVhLtaPZY:3:CL:39777:default",
+        "last_issue_date": "2020-09-24T10:48:42.355926-07:00",
+        "url": "/bcreg/address",
+        "schema": { ... }
+      },
+      "addresses": [],
+      "attributes": [
+        {
+          "id": 15367395,
+          "type": "business_number",
+          "format": "attribute",
+          "value": "000760180",
+          "credential_id": 2888463
+        }
+      ],
+      "names": [],
+      "topic": { ... },
+      "related_topics": []
+    },
+    ...
+  ]
 }
 ```
 
-You'll notice that it contains many of the same fields as the top-level response, with some additions, such as `source_id` (the unique registration number generated for the organization), `addresses` and `local_name`.
+Two credentials have been returned in the results. Locating the `credential_type` field, the `description` indicates that one of the credentials is of the type `'registration.registries.ca'` and the other is of the type `'business_number.registries.ca'`.
 
-The `names` field contains the operating business names and has the following type definition (with `type` typically being `'entity_name'`):
+The first credential contains registration information about the organization. The list of `attributes` contains various fields, such as `'entity_status'`, `'entity_type'` and others. The registration credential attributes for this organization indicate that this is an Active, BC Company.
 
-```
-interface CredentialName {
-  id: number;
-  text: string;
-  language: string;
-  credential_id: string;
-  type: string;
-}
-```
+In another unrelated example, the following attribute list tells us that the organization is an Active, Sole Proprietorship within British Columbia:
 
-The `attributes` field is a list that likely contains a lot of information you are going to be interested in about the entity such as `'registration_date'`, `'entity_name_effective'`, `'entity_status'`, `'entity_status_effective'`, `'entity_type'`, `'home_jurisdiction'`, and `'reason_description'`. It has the following type definition:
-
-```
-interface TopicAttribute {
-  id: number;
-  type: string;
-  format: string;
-  value: string;
-  credential_id: string;
-  credential_type_id: string;
-}
-```
-
-For example the following attribute list tells us that the organization is an active Sole Proprietorship within British Columbia:
-
-```
+```json
 "attributes": [
     {
         "id": ...,
@@ -285,94 +367,10 @@ For example the following attribute list tells us that the organization is an ac
 ]
 ```
 
-#### Example
+The second credential contains information about the organization's business number, issued by the Canada Revenue Agency for tax purposes. There is only a single attribute for the `'business_number'`. The `'value'` is the business number itself.
 
-> Checkout this [example](https://stackblitz.com/edit/js-je6ckp?file=index.js) on Stackblitz for a simple implementation using jQuery and plain HTML.
+Together these credentials can be used to programmatically fill in form fields in an application.
 
-### Faceted organization search
+#### Implementation Example 2
 
-Faceted search augments basic search functionality by providing a mechanism to narrow down search results through the application of various filters, similar to what you would see on an e-commerce site like an online clothing store. _See [this](https://en.wikipedia.org/wiki/Faceted_search) Wikipedia article about faceted search._
-
-The `/search/topic/facets` path has been created specifically for this and works exactly the same as `search/topic` with the only difference being that the response is augmented with facets.
-
-#### Request
-
-Example (using `'abc'` as the query string):
-
-```
-/search/topic/facets?name=abc&inactive=false&latest=true&revoked=false
-```
-
-#### Response
-
-The API response will have the following type definition, where `objects` is the same as the response body of `/search/topic` (see above):
-
-```
-interface TopicFacetsResponse {
-  facets: TopicFacets;
-  objects: TopicResponse;
-}
-```
-
-The `facets` field has the following type definition, of which, `fields` are lists of objects that describe topics, grouped together by query parameters that can be added to a topic search.
-
-```
-interface TopicFacets {
-  fields: TopicFacetFields;
-  dates: TopicFacetDates;
-  queries: TopicFacetQueries;
-}
-```
-
-For example, the `category` facet field contains a number of objects with properties such as `entity_type`, `entity_status`, etc:
-
-```
-{
-  category: [ ... ];
-  credential_type_id: [ ... ];
-  issuer_id: [ ... ];
-}
-```
-
-Field objects have the following type definition:
-
-```
-export interface TopicFacetField {
-    value: string;
-    count: number;
-    text: string;
-}
-```
-
-The `value` field denotes the specific term to add to the `/search/topic` or `/search/topic/facets` paths to narrow a topic search down. The `count` field denotes how many topics are categorized by that term for the current topic search.
-
-For example, suppose the following facets were returned from a topic search:
-
-```
-{
-  category: [
-    {
-        "value": "entity_status::ACT",
-        "count": 480
-    },
-    {
-        "value": "entity_type::SP",
-        "count": 302
-    },
-    {
-        "value": "entity_type::BC",
-        "count": 114
-    },
-    {
-        "value": "entity_type::GP",
-        "count": 49
-    }
-  ];
-}
-```
-
-The current search results would contain all entity types that match or closely match an organization of interest. Appending the field name as a query parameter and the value as the query parameter value to the topic search (for example, `'?category=entity_type::GP'`) would narrow down search results only to organizations that are General Partnerships.
-
-<!-- ### Organization credential verification -->
-<!-- ### Credential issuer search -->
-<!-- ### Credential type search -->
+> Checkout this [example](https://stackblitz.com/edit/js-y5jxtf) on StackBlitz for a simple implementation of auto-populating a form from OrgBook credentials using jQuery UI and plain HTML.


### PR DESCRIPTION
This PR updates OrgBook API documentation.

Changelog:
- Relaxes the technical details of the API (such as describing types of responses) to focus more on how to achieve particular goals.
- Wording has been reconstructed in a guide-like language (for example, _How can I find what types of Credentials OrgBook has?_, _How do I auto-populate form fields using OrgBook data?_)
- Examples have been expanded to better illustrate OrgBook API concepts.
- Adds some introductory information about what OrgBook is, and what an Aries VCR is.